### PR TITLE
3.0.1-testonly-03 test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,10 @@ android {
       excludes += '/META-INF/{AL2.0,LGPL2.1}'
     }
   }
+
+  configurations.configureEach {
+    resolutionStrategy { cacheChangingModulesFor 0, 'seconds' }
+  }
 }
 
 dependencies {
@@ -71,8 +75,7 @@ dependencies {
 
   // Zowie 0.1.1 has incorrect obfuscation strategy (default, consecutive alphabet letters, no package, no prefix)
   // The problem is fixed in zowie 0.1.2
-  implementation 'ai.zowie:android-sdk:0.1.1'
-//  implementation 'ai.zowie:android-sdk:0.1.2'
+  implementation 'ai.zowie:android-sdk:0.1.2'
 
   // When checkout 3ds is added to the project together with ai.zowie:0.1.1, we have the following error:
   // Duplicate class a.a found in modules android-sdk-0.1.1-runtime (ai.zowie:android-sdk:0.1.1) and checkout-sdk-3ds-android-2.0.4-runtime (com.checkout:checkout-sdk-3ds-android:2.0.4)
@@ -86,7 +89,7 @@ dependencies {
   // Duplicate class f.c found in modules android-sdk-0.1.1-runtime (ai.zowie:android-sdk:0.1.1) and checkout-sdk-3ds-android-2.0.4-runtime (com.checkout:checkout-sdk-3ds-android:2.0.4)
   // Duplicate class g.a found in modules android-sdk-0.1.1-runtime (ai.zowie:android-sdk:0.1.1) and checkout-sdk-3ds-android-2.0.4-runtime (com.checkout:checkout-sdk-3ds-android:2.0.4)
   // Duplicate class g.b found in modules android-sdk-0.1.1-runtime (ai.zowie:android-sdk:0.1.1) and checkout-sdk-3ds-android-2.0.4-runtime (com.checkout:checkout-sdk-3ds-android:2.0.4)
-  implementation 'com.checkout:checkout-sdk-3ds-android:3.0.1-testonly-01'
+  implementation 'com.checkout:checkout-sdk-3ds-android:3.0.1-testonly-03'
 
   // when frames is added to the project together with checkout 3ds, we have the following error:
   // Type com.checkout.eventlogger.R is defined multiple times: /Users/jangonera/projekty/poligon/checkoutminify/app/build/intermediates/compile_and_runtime_not_namespaced_r_class_jar/debug/R.jar:com/checkout/eventlogger/R.class, /Users/jangonera/.gradle/caches/transforms-3/31d124a7cd8ba916f4f23c0cd71dc755/transformed/checkout-sdk-3ds-android-2.0.4-runtime.jar:com/checkout/eventlogger/R.class

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -50,15 +50,25 @@
 
 #Note:This is warning class being exposed from the checkout 3DS SDK and its known issue. We are adding dontwanr class rules
 # in 3DS SDK because it is not necessary to expose to merchant who use 3DS SDK. However, currently workaround of adding missing rules in proguard able to resolve missing class rules compile error
--dontwarn b.a.c.g.b
--dontwarn b.a.c.g.f
--dontwarn b.a.c.g.k$a
--dontwarn b.a.c.g.k$b
--dontwarn b.a.c.g.o
--dontwarn b.a.c.g.p
--dontwarn b.a.c.g.t
--dontwarn b.a.c.l.a
--dontwarn com.checkout.sessions.data.mapper.KeyMapper
+#-dontwarn b.a.c.g.b
+#-dontwarn b.a.c.g.f
+#-dontwarn b.a.c.g.k$a
+#-dontwarn b.a.c.g.k$b
+#-dontwarn b.a.c.g.o
+#-dontwarn b.a.c.g.p
+#-dontwarn b.a.c.g.t
+#-dontwarn b.a.c.l.a
+-dontwarn com.cko.threedsobfuscation.d2
+-dontwarn com.cko.threedsobfuscation.i2$a
+-dontwarn com.cko.threedsobfuscation.m2
+-dontwarn com.cko.threedsobfuscation.n2
+-dontwarn com.cko.threedsobfuscation.q7
+-dontwarn com.cko.threedsobfuscation.r2
+-dontwarn com.cko.threedsobfuscation.z1
+-dontwarn com.cko.threedsobfuscation.g6
+-dontwarn com.cko.threedsobfuscation.f6
+-dontwarn com.cko.threedsobfuscation.f6.a
+-dontwarn com.cko.threedsobfuscation.i2$b
 #
 #-dontwarn com.google.errorprone.annotations.Immutable
 #-dontwarn d.a.c.g.b

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,13 @@ allprojects {
     maven {
       url = uri("https://maven.pkg.github.com/checkout/checkout-3ds-sdk-android")
       credentials {
-        username = githubTokenUserName
-        password = githubToken
+        username = "usernameo"
+        password = "token"
+        // Please add permission for write packages while creating token
       }
+    }
+    maven {
+      url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
     }
     maven { url 'https://jitpack.io' }
     maven {


### PR DESCRIPTION
Added [3.0.1-testonly-03](https://github.com/checkout/checkout-3ds-sdk-android/packages/929646?version=3.0.1-testonly-03) in sample app using [2.0.2-SNAPSHOT](https://github.com/cko-payment-interfaces/checkout-sdk-event-logger-android/releases/tag/2.0.2-SNAPSHOT) Logging SDK. 

Test result:
1. Obfuscation working as expected for 3DS SDK, see attached screenshot
2. However, missing class rules still required to add in 3DS SDK to run successfully

Observation and pending:
1. 3DS SDK add an event logger as a jar file along with it, not compiled version. Resulting in event logger R class defined multiple times. Required to investigate the purpose of it and it does require otherwise merchant app will have crash I have tested it
2. Although adding the repackaging rule to 3DS SDK (working as expected) and Logging SDK, adding Frames results in the same error saying the R class from the event logger is defined multiple times. 

To summarise, we have added a repackaging rule to 3DS SDK which is working as expected. However, adding a repackaging rule to Logging SDK did not resolve the problem. We need to verify what needs to be changed when 3DS is using the Jar file of eventLogger and Frames using the compiled version

<img width="799" alt="Screenshot 2023-05-05 at 17 43 15" src="https://user-images.githubusercontent.com/114917119/236517361-bffe3589-cd85-4a58-96e3-55f80b826e08.png">
